### PR TITLE
Bugfix: ambiguous redirect

### DIFF
--- a/.github/workflows/Test.yaml
+++ b/.github/workflows/Test.yaml
@@ -26,6 +26,10 @@ jobs:
           repoOwner: ${{ github.repository_owner }}
           repoName:  ${{ github.event.repository.name }}
 
+      - name: Set pageId output
+        id: set_page_id
+        run: echo "pageId=${{ steps.run_action.outputs.pageId }}" >> $GITHUB_ENV          
+
       - name: Clean up
         id: cleanup
         if: success()

--- a/action.yml
+++ b/action.yml
@@ -137,4 +137,3 @@ runs:
           exit 1
         fi
         echo "pageId=$pageId" >> $GITHUB_ENV
-        echo "pageId=$pageId" >> $GITHUB_ENV_FILE


### PR DESCRIPTION
**Description:**
- Remove not need the echo "pageId=$pageId" >> $GITHUB_ENV_FILE
- Added a new step Set pageId output to set the pageId as an environment variable using the set-output command.
- Updated the Clean up step to retrieve the pageId from the environment variable.
**Related issue:**
[link to the related issue.](https://github.com/Gershon-A/publish-release-to-confluence/issues/4)

**Check list:**
- [] Mark if documentation changes are required.
- [x] Mark if tests were added or updated to cover the changes.